### PR TITLE
Allow to localize several strings at once

### DIFF
--- a/shared/l10n.js
+++ b/shared/l10n.js
@@ -28,12 +28,27 @@ LocalizationHelper.prototype = {
   },
 
   /**
-   * L10N shortcut function.
+   * L10N shortcut function. Can be used with a single string or an array of
+   * strings.
    *
-   * @param {String} name
+   * @param {String|Array} name
    * @return {String}
    */
   getString: async function(name) {
+    if (Array.isArray(name)) {
+      const strings = [];
+
+      for (const i = 0; i < name.length; i++) {
+        const properties = await this.fetchBundle();
+        if (name[i] in properties) {
+          strings.push(properties[name]);
+        } else {
+          throw new Error("No localization found for [" + name[i] + "]");
+        }
+      }
+      return strings;
+    }
+
     const properties = await this.fetchBundle();
     if (name in properties) {
       return properties[name];


### PR DESCRIPTION
### Context

Firefox is available in many languages and all the text displayed in the Browser, including DevTools should be localized. 
This means strings are not hardcoded, but instead are dynamically translated. 
LocalizationHelper is one of the helpers used in Firefox DevTools to translate strings.

It is used as follows:
```javascript
// Create a LocalizationHelper reading localized strings from a "toolbox.properties" 
// file, which is called a bundle.
const localizationHelper = new LocalizationHelper(
  "devtools/client/locales/toolbox.properties"
);

// Retrieve the translation of a string. Here "toolbox.defaultTitle" is a key identifying 
// a localized string.
const localizedTitle = await localizationHelper.getString(
  "toolbox.defaultTitle"
);
 ```

Note that we don't have to specify the locale anywhere in this API, the Firefox build system will ensure that the "bundles" we load correspond to the current locale.

### Problem

The `getString` API currently accepts a single string argument. 
When we load a UI which needs to load dozens of strings, we have to call this API a lot of times.
We want to modify `getString` to also accept an array of strings rather than only a single string at a time.
Also, `getString` is a slow API and can be a bottleneck. When localizing several strings at the same time, we expect better performance.

### The PR  

A PR was submitted to address the issue above, try to review it as if you were a DevTools maintainer. 
Also look out for mistakes, inconsistencies and omissions.