### PR TITLE
Remove MultiLocalizationHelper

### DIFF
--- a/client/debugger/panel.js
+++ b/client/debugger/panel.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-const { MultiLocalizationHelper } = require("devtools/shared/l10n");
+const l10n = require("devtools/shared/l10n");
 
 loader.lazyRequireGetter(
   this,
@@ -24,12 +24,11 @@ loader.lazyRequireGetter(
 );
 
 const DBG_STRINGS_URI = [
-  "devtools/client/locales/debugger.properties",
-  // These are used in the AppErrorBoundary component
-  "devtools/client/locales/startup.properties",
   "devtools/client/locales/components.properties",
+  "devtools/client/locales/debugger.properties",
+  "devtools/client/locales/startup.properties",
 ];
-const L10N = new MultiLocalizationHelper(...DBG_STRINGS_URI);
+const L10N = new l10n.LocalizationHelper(DBG_STRINGS_URI);
 
 async function getNodeFront(gripOrFront, toolbox) {
   // Given a NodeFront

--- a/client/definitions.js
+++ b/client/definitions.js
@@ -99,8 +99,8 @@ loader.lazyRequireGetter(
   true
 );
 
-const { MultiLocalizationHelper } = require("devtools/shared/l10n");
-const L10N = new MultiLocalizationHelper(
+const l10n = require("devtools/shared/l10n");
+const L10N = new l10n.LocalizationHelper(
   "devtools/client/locales/startup.properties",
   "devtools/startup/locales/key-shortcuts.properties"
 );

--- a/client/shared/widgets/Spectrum.js
+++ b/client/shared/widgets/Spectrum.js
@@ -5,7 +5,7 @@
 "use strict";
 
 const EventEmitter = require("devtools/shared/event-emitter");
-const { MultiLocalizationHelper } = require("devtools/shared/l10n");
+const l10n = require("devtools/shared/l10n");
 
 loader.lazyRequireGetter(this, "colorUtils", "devtools/shared/css/color", true);
 loader.lazyRequireGetter(
@@ -21,7 +21,7 @@ loader.lazyRequireGetter(
   true
 );
 
-const L10N = new MultiLocalizationHelper(
+const L10N = new l10n.MultiLocalizationHelper(
   "devtools/client/locales/accessibility.properties",
   "devtools/client/locales/inspector.properties"
 );

--- a/shared/l10n.js
+++ b/shared/l10n.js
@@ -12,11 +12,11 @@ const { sprintf } = require("devtools/shared/sprintfjs/sprintf");
  * @param string bundleName
  *        The desired string bundle's name.
  */
-function LocalizationHelper(bundleName) {
+function BundleHelper(bundleName) {
   this.bundleName = bundleName;
 }
 
-LocalizationHelper.prototype = {
+BundleHelper.prototype = {
   /**
    * Download and parse the localized strings bundle.
    *
@@ -73,28 +73,30 @@ LocalizationHelper.prototype = {
  * A helper for having the same interface as LocalizationHelper, but for more
  * than one file. Useful for abstracting l10n string locations.
  */
-function MultiLocalizationHelper(...bundleNames) {
-  const instances = bundleNames.map(bundle => {
-    return new LocalizationHelper(bundle);
+function LocalizationHelper(...bundleNames) {
+  if (Array.isArray(bundleNames[0])) {
+    console.log("Support passing a single array argument");
+    bundleNames = bundleNames[0];
+  }
+
+  const instances = bundleNames.map(b => {
+    return new BundleHelper(b);
   });
 
   // Get all function members of the LocalizationHelper class, making sure we're
   // not executing any potential getters while doing so, and wrap all the
   // methods we've found to work on all given string bundles.
-  Object.getOwnPropertyNames(LocalizationHelper.prototype)
-    .map(name => ({
-      name: name,
-      descriptor: Object.getOwnPropertyDescriptor(
-        LocalizationHelper.prototype,
-        name
-      ),
+  Object.getOwnPropertyNames(BundleHelper.prototype)
+    .map(n => ({
+      name: n,
+      descriptor: Object.getOwnPropertyDescriptor(BundleHelper.prototype, n),
     }))
     .filter(({ descriptor }) => descriptor.value instanceof Function)
     .forEach(method => {
       this[method.name] = (...args) => {
-        for (const l10n of instances) {
+        for (const i of instances) {
           try {
-            return method.descriptor.value.apply(l10n, args);
+            return method.descriptor.value.apply(i, args);
           } catch (e) {
             // Do nothing
           }
@@ -105,4 +107,3 @@ function MultiLocalizationHelper(...bundleNames) {
 }
 
 exports.LocalizationHelper = LocalizationHelper;
-exports.MultiLocalizationHelper = MultiLocalizationHelper;

--- a/shared/tests/browser/browser_l10n.js
+++ b/shared/tests/browser/browser_l10n.js
@@ -7,7 +7,6 @@
 
 const {
   LocalizationHelper,
-  MultiLocalizationHelper,
 } = require("devtools/shared/l10n");
 
 add_task(async function() {
@@ -25,29 +24,5 @@ add_task(async function() {
     formattedString,
     "DOM and Style Inspector (test)",
     "LocalizationHelper could format a string with a parameter"
-  );
-
-  const multiLocalizationHelper = new MultiLocalizationHelper(
-    "devtools/client/locales/startup.properties",
-    "devtools/client/locales/toolbox.properties"
-  );
-  const str1 = await multiLocalizationHelper.getString("inspector.label");
-  is(
-    str1,
-    "Inspector",
-    "MultiLocalizationHelper could retrieve a string from startup.properties"
-  );
-
-  const str2 = await multiLocalizationHelper.getString("toolbox.defaultTitle");
-  is(
-    str2,
-    "Developer Tools",
-    "MultiLocalizationHelper could retrieve a string from toolbox.properties"
-  );
-
-  await Assert.rejects(
-    multiLocalizationHelper.getString("missing.string"),
-    /No localization found for \[missing\.string\]/,
-    "MultiLocalizationHelper throws for a missing string"
   );
 });


### PR DESCRIPTION

### Context 

As we have seen in the previous exercise, localized strings are stored in properties bundles. And for each properties bundles, we need to create a different LocalizationHelper:
```
const toolboxHelper = new LocalizationHelper("devtools/client/locales/toolbox.properties"); 
const webconsoleHelper = new LocalizationHelper("devtools/client/locales/webconsole.properties"); 
```
And then depending on which string you want to read, you need to use the correct LocalizationHelper instance. This was annoying to use when a class regularly needed to read from several bundles, so we introduced a while ago the "MultiLocalizationHelper". This class offers the same API as the LocalizationHelper, but can read from several bundles. 

```
const multiHelper = new MultiLocalizationHelper(
  "devtools/client/locales/toolbox.properties", 
  "devtools/client/locales/webconsole.properties"
); 
```

This is not used in too many places but it is a useful alternative to LocalizationHelper when you need several sources.

### Issue

It seems unnecessary to keep LocalizationHelper and MultiLocalizationHelper as separated classes. Instead, we want to remove MultiLocalizationHelper, and make it so that LocalizationHelper transparently works with one or several properties bundle files. 

### PR

A PR was submitted to address the issue above, try to review it as if you were a DevTools maintainer.
Also look out for mistakes, inconsistencies and omissions.